### PR TITLE
Add /data & /log folders creation

### DIFF
--- a/j-build.sh
+++ b/j-build.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 read -p "Set the variable jenkins-user: " juser
 read -sp "Set the variable jenkins-password: " jpass
+#Creates folders that will mounted as volumes
+if [[ ! -d "./master/data" ]]; then
+    mkdir "./master/data"
+fi
+if [[ ! -d "./master/log" ]]; then
+    mkdir "./master/log"
+fi
+if [[ ! -d "./nexus/data" ]]; then
+    mkdir "./nexus/data"
 #read -p "Provide URL where the seed job placed: " SEED_JOBS_URL
 rm -rf ./master/data/* ./master/log/* ./nexus/data/*
 echo $juser > ./master/data/juser && echo $jpass > ./master/data/jpass

--- a/j-build.sh
+++ b/j-build.sh
@@ -10,6 +10,7 @@ if [[ ! -d "./master/log" ]]; then
 fi
 if [[ ! -d "./nexus/data" ]]; then
     mkdir "./nexus/data"
+fi    
 #read -p "Provide URL where the seed job placed: " SEED_JOBS_URL
 rm -rf ./master/data/* ./master/log/* ./nexus/data/*
 echo $juser > ./master/data/juser && echo $jpass > ./master/data/jpass


### PR DESCRIPTION
./master/data, ./master/log, ./nexus/data folders does not exist from scratch. 
Variables jpass and juser cannot be passed along this path.
Folders will be created after starting the containers at the volume creation step, and will be owned by the root user.  Jenkins and Nexus cannot writes to these volumes, receives the "permission denied" error and down.
